### PR TITLE
Fixing possible typo in TIMES prefix definition

### DIFF
--- a/doc/nasmdoc.src
+++ b/doc/nasmdoc.src
@@ -1368,7 +1368,7 @@ times. This is partly present as NASM's equivalent of the \i\c{DUP}
 syntax supported by \i{MASM}-compatible assemblers, in that you can
 code
 
-\c zerobuf:        times 64 db 0
+\c zerobuf:        db 64 dup(0)
 
 or similar things; but \c{TIMES} is more versatile than that. The
 argument to \c{TIMES} is not just a numeric constant, but a numeric

--- a/doc/nasmdoc.src
+++ b/doc/nasmdoc.src
@@ -1472,7 +1472,7 @@ In 64-bit mode, NASM will by default generate absolute addresses.  The
 this is frequently the normally desired behaviour, see the \c{DEFAULT}
 directive (\k{default}). The keyword \i\c{ABS} overrides \i\c{REL}.
 
-A new form of split effective addres syntax is also supported. This is
+A new form of split effective address syntax is also supported. This is
 mainly intended for mib operands as used by MPX instructions, but can
 be used for any memory reference. The basic concept of this form is
 splitting base and index.


### PR DESCRIPTION
Due to sentence "This is partly present as NASM's equivalent of the DUP syntax supported by MASM-compatible assemblers, in that you can code" I assumed that the line of code should be with MASM stuff, so I corrected it.
